### PR TITLE
TestVehicleController fails at the deconstruction of MapParameterToDevices

### DIFF
--- a/test/UnitTests/TestVehicleController/AccessControl.cpp
+++ b/test/UnitTests/TestVehicleController/AccessControl.cpp
@@ -1,0 +1,25 @@
+#include "AccessControl.h"
+
+AccessControl::AccessControl()
+  : m_handleMutex(NULL)
+{
+  m_handleMutex = xSemaphoreCreateMutex();
+}
+
+
+AccessControl::~AccessControl()
+{
+  vSemaphoreDelete(m_handleMutex);
+}
+
+
+void AccessControl::lock()
+{
+  xSemaphoreTake(m_handleMutex, portMAX_DELAY);
+}
+
+
+void AccessControl::unlock()
+{
+  xSemaphoreGive(m_handleMutex);
+}

--- a/test/UnitTests/TestVehicleController/AccessControl.h
+++ b/test/UnitTests/TestVehicleController/AccessControl.h
@@ -1,0 +1,27 @@
+/* ======================================================================
+ * An adapter for access controlling objects like semaphores. Can be
+ * customised to the operating system used and other needs.
+ */
+
+#ifndef ACCESSCONTROL_H
+#define ACCESSCONTROL_H
+
+#include <Arduino.h>
+//#include <Arduino_FreeRTOS.h>
+//#include <semphr.h>
+//#include "freertos/FreeRTOS.h"
+//#include "freertos/semphr.h"
+
+class AccessControl
+{
+public:
+  AccessControl();
+  ~AccessControl();
+  void lock();
+  void unlock();
+
+private:
+  SemaphoreHandle_t m_handleMutex;
+};
+
+#endif

--- a/test/UnitTests/TestVehicleController/AccessLock.cpp
+++ b/test/UnitTests/TestVehicleController/AccessLock.cpp
@@ -1,0 +1,13 @@
+#include "AccessLock.h"
+
+AccessLock::AccessLock(AccessControl* pMutex)
+  : m_pMutex(pMutex)
+{
+	m_pMutex->lock();
+}
+
+
+AccessLock::~AccessLock()
+{
+	m_pMutex->unlock();
+}

--- a/test/UnitTests/TestVehicleController/AccessLock.h
+++ b/test/UnitTests/TestVehicleController/AccessLock.h
@@ -1,0 +1,22 @@
+/* ======================================================================
+ * This is an automation for AccessControl. Creating an AccessLock at the
+ * beginning of a scope will lock the given AccessControl and
+ * automatically free it at the end of the scope.
+ */
+
+#ifndef ACCESSLOCK_H
+#define ACCESSLOCK_H
+
+#include "AccessControl.h"
+
+class AccessLock
+{
+public:
+	AccessLock(AccessControl* pMutex);
+	~AccessLock();
+
+private:
+	AccessControl* m_pMutex;
+};
+
+#endif

--- a/test/UnitTests/TestVehicleController/Constants.h
+++ b/test/UnitTests/TestVehicleController/Constants.h
@@ -1,0 +1,22 @@
+/* ======================================================================
+ * Central location for saving microcontroller-specific constants such
+ * as I/O pins.
+ */
+
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#include <Arduino.h>
+
+// Development settings
+#define DEBUG 1
+#define START_SERIAL Serial.begin(9600);
+#define PRINT(msg) Serial.println(msg);
+
+#define RESET ESP.restart() // For ESP32
+// For Arduino Due: rstc_start_software_reset(RSTC)
+
+// Size of an event queue
+#define QUEUE_SIZE 20
+
+#endif

--- a/test/UnitTests/TestVehicleController/MapParameterToDevices.cpp
+++ b/test/UnitTests/TestVehicleController/MapParameterToDevices.cpp
@@ -1,0 +1,111 @@
+#include "MapParameterToDevices.h"
+
+
+bool MapParameterToDevices::addParameterToMap(Parameter* pNewParam)
+{
+  // See whether the parameter is already registered and break in this case
+  if (this->has(pNewParam->getId())) {
+    if (DEBUG) {PRINT("Parameter already added with ID " + String(pNewParam->getId()))}
+    return false;
+  }
+  else {
+    // Create the new list on the heap
+    SecuredLinkedList<Device*>* devicesList = new SecuredLinkedList<Device*>();
+    // Add it to the end of this list
+    this->put(pNewParam->getId(), devicesList);
+    return true;
+  }
+}
+
+
+bool MapParameterToDevices::registerForValueChanged(Device* pCallingDevice, int id)
+{
+  // Find the given ID and add the device to its list
+  if (!this->has(id)) {
+    if (DEBUG) {PRINT("No parameter found with ID " + String(id))}
+    return false;
+  }
+  // See whether the device is already registered
+  for (unsigned int i=0; i<this->get(id)->size(); i++) {
+    if (this->get(id)->get(i) == pCallingDevice) {
+      if (DEBUG) {PRINT("Device already registered for parameter with ID " + String(id))}
+      return false;
+    }
+  }
+  // If not, register it
+  this->get(id)->push(pCallingDevice);
+  return true;
+}
+
+
+bool MapParameterToDevices::unregisterForValueChanged(Device* pCallingDevice, int id)
+{
+  // Find the given ID and remove the device there
+  if (!this->has(id)) {
+    return false;
+  }
+  return MapParameterToDevices::removeDeviceFromList(this->get(id), pCallingDevice);
+}
+
+/*
+bool MapParameterToDevices::unregisterDevice(Device* pCallingDevice)
+{
+  // Remove device from all elements of this list
+  int boolSum = 0;
+  SecuredLinkedListMapElement<int, SecuredLinkedList<Device*>*> mapCopy[this->size()];
+  for (int i=0; i<this->size(); i++) {
+    bool returnVal = MapParameterToDevices::removeDeviceFromList(mapCopy[i].value, pCallingDevice);
+    boolSum = boolSum + returnVal;
+  }
+  // Return if the device was removed at least once
+  if (boolSum > 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+*/
+
+SecuredLinkedList<Device*>* MapParameterToDevices::getRegisteredDevices(int id)
+{
+  // Return a pointer to the device list of the given ID
+  if (!this->has(id)) {
+    // Return NULL if the ID was not found
+    return NULL;
+  }
+  return this->get(id);
+}
+
+
+bool MapParameterToDevices::removeDeviceFromList(SecuredLinkedList<Device*>* pDevicesList, Device* pDevice)
+{
+  // Search the given list for the given device
+  for (unsigned int i=0; i<pDevicesList->size(); i++) {
+    Device* pDev = pDevicesList->get(i);
+    // Compare the pointers
+    if (pDev == pDevice) {
+      // Pop that device: To do so, pop all devices above it or all below it
+      if (i == pDevicesList->size()-1) {
+        Device* trash = pDevicesList->pop();
+      } else if (i == 0) {
+        Device* trash = pDevicesList->shift();
+      } else {
+        // Pop everything above and add it again
+        int head = pDevicesList->size() - i - 1;
+        Device* tempStorage[head];
+        for (unsigned int j=0; j<head; j++) {
+          tempStorage[j] = pDevicesList->pop();
+        }
+        Device* trash = pDevicesList->pop();
+        for (unsigned int j=0; j<head; j++) {
+          pDevicesList->push(tempStorage[j]);
+        }
+      }
+      // Return success
+      return true;
+    }
+  }
+  // Return false, if nothing happened
+  if (DEBUG) {PRINT("No device found to unregister")}
+  return false;
+}

--- a/test/UnitTests/TestVehicleController/MapParameterToDevices.h
+++ b/test/UnitTests/TestVehicleController/MapParameterToDevices.h
@@ -1,0 +1,34 @@
+/* ======================================================================
+ * This map-like class is based on the SecuredLinkedList by Steven Cybinski.
+ * It is a list of elements, which contain one Parameter and a list of
+ * Devices, which are registered for its changes. The element can be
+ * identified by the Parameter's ID.
+ */
+
+#ifndef MAPPARAMETERTODEVICES_H
+#define MAPPARAMETERTODEVICES_H
+
+#include <Arduino.h>
+#include "Parameter.h"
+#include "SecuredLinkedList.h"
+#include "SecuredLinkedListMap.h"
+#include "Constants.h"
+#include "Device.h"
+
+
+class MapParameterToDevices : public SecuredLinkedListMap<int, SecuredLinkedList<Device*>*>
+{
+public:
+  MapParameterToDevices() {};
+  ~MapParameterToDevices() {};
+  bool addParameterToMap(Parameter* pNewParam);
+  bool registerForValueChanged(Device* pCallingDevice, int id);
+  bool unregisterForValueChanged(Device* pCallingDevice, int id);
+  //bool unregisterDevice(Device* pCallingDevice);
+  SecuredLinkedList<Device*>* getRegisteredDevices(int id);
+
+private:
+  bool removeDeviceFromList(SecuredLinkedList<Device*>* pDevicesList, Device* pDevice);
+};
+
+#endif

--- a/test/UnitTests/TestVehicleController/Parameter.cpp
+++ b/test/UnitTests/TestVehicleController/Parameter.cpp
@@ -1,0 +1,43 @@
+#include "Parameter.h"
+
+
+void ParameterBool::setVal(bool val)
+{
+  AccessLock lock(&m_phMutex);
+  m_value = val;
+}
+
+
+bool ParameterBool::getVal()
+{
+  AccessLock lock(&m_phMutex);
+  return m_value;
+}
+
+
+void ParameterInt::setVal(int val)
+{
+  AccessLock lock(&m_phMutex);
+  m_value = val;
+}
+
+
+int ParameterInt::getVal()
+{
+  AccessLock lock(&m_phMutex);
+  return m_value;
+}
+
+
+void ParameterDouble::setVal(double val)
+{
+  AccessLock lock(&m_phMutex);
+  m_value = val;
+}
+
+
+double ParameterDouble::getVal()
+{
+  AccessLock lock(&m_phMutex);
+  return m_value;
+}

--- a/test/UnitTests/TestVehicleController/Parameter.h
+++ b/test/UnitTests/TestVehicleController/Parameter.h
@@ -1,0 +1,59 @@
+/* ======================================================================
+ * A Parameter can hold one value of the respective data type. It needs
+ * a mutex that is called when the value is set or retrieved.
+ */
+
+#ifndef PARAMETER_H
+#define PARAMETER_H
+
+#include <Arduino.h>
+#include "AccessControl.h"
+#include "AccessLock.h"
+
+class Parameter
+{
+public:
+  AccessControl m_phMutex;
+  
+  Parameter(int id) : m_phMutex(AccessControl()), m_id(id) {};
+  int getId() {return m_id;};
+
+private:
+  int m_id;
+};
+
+
+class ParameterBool : public Parameter
+{
+public:
+  ParameterBool(int id) : Parameter(id), m_value(0) {};
+  void setVal(bool val);
+  bool getVal();
+private:
+  bool m_value;
+  
+};
+
+
+class ParameterDouble : public Parameter
+{
+public:
+  ParameterDouble(int id) : Parameter(id), m_value(0) {};
+  void setVal(double val);
+  double getVal();
+private:
+  double m_value;
+};
+
+
+class ParameterInt : public Parameter
+{
+public:
+  ParameterInt(int id) : Parameter(id), m_value(0) {};
+  void setVal(int val);
+  int getVal();
+private:
+  int m_value;
+};
+
+#endif

--- a/test/UnitTests/TestVehicleController/Queue.cpp
+++ b/test/UnitTests/TestVehicleController/Queue.cpp
@@ -1,0 +1,49 @@
+#include "Queue.h"
+
+Queue::Queue(size_t sizeOfElement)
+  : m_handleQueue(NULL), m_phMutex(NULL)
+{
+  m_phMutex = new AccessControl();
+  m_handleQueue = xQueueCreate(QUEUE_SIZE, sizeOfElement);
+  if (m_handleQueue==NULL) {
+    if (DEBUG) {PRINT("Fatal: Queue generation failed")}
+  }
+}
+
+
+Queue::~Queue()
+{
+  delete m_phMutex;
+  vQueueDelete(m_handleQueue);
+  m_handleQueue = NULL;
+}
+
+
+bool Queue::empty()
+{
+  AccessLock lock(m_phMutex);
+  Parameter* element;
+  // Don't wait, if the element is not immediately available
+  return !xQueuePeek(m_handleQueue, &element, (TickType_t)0);
+}
+
+
+Parameter* Queue::pop()
+{
+  AccessLock lock(m_phMutex);
+  Parameter* element = NULL;
+  // Don't wait, if the element is not immediately available
+  xQueueReceive(m_handleQueue, &element, (TickType_t)0);
+  return element;
+}
+
+
+bool Queue::push(Parameter* pParam)
+{
+  AccessLock lock(m_phMutex);
+  // Wait 10 ticks if the queue is already full
+  if (xQueueSend(m_handleQueue, &pParam, (TickType_t)10) != pdPASS) {
+    return false;
+  }
+  return true;
+}

--- a/test/UnitTests/TestVehicleController/Queue.h
+++ b/test/UnitTests/TestVehicleController/Queue.h
@@ -1,0 +1,34 @@
+/* ======================================================================
+ * An adapter for queues. Can be customised to the operating system used
+ * and other needs such as return type.
+ */
+
+#ifndef CUSTOM_QUEUE_H
+#define CUSTOM_QUEUE_H
+
+#include <Arduino.h>
+//#include <Arduino_FreeRTOS.h>
+//#include <queue.h>
+//#include "freertos/FreeRTOS.h"
+//#include "freertos/queue.h"
+#include "Constants.h"
+#include "AccessControl.h"
+#include "AccessLock.h"
+
+class Parameter;
+
+class Queue
+{
+public:
+  Queue(size_t sizeOfElement);
+  ~Queue();
+  bool empty();
+  Parameter* pop();
+  bool push(Parameter* pParam);
+
+private:
+  AccessControl* m_phMutex;
+  QueueHandle_t m_handleQueue;
+};
+
+#endif

--- a/test/UnitTests/TestVehicleController/SecuredLinkedList.h
+++ b/test/UnitTests/TestVehicleController/SecuredLinkedList.h
@@ -1,0 +1,234 @@
+// Based on a project by Steven Cybinski
+// GitHub documentation: https://github.com/StevenCyb/SecuredLinkedList
+// Modifications:
+// - replaced std::mutex with FreeRTOS mutex
+// - added object initiliser list (important for functionality)
+// - added clear function to destructor to prevent heap issues
+// - delete all nodes in clear function to prevent heap issues
+
+#ifndef SecuredLinkedList_h
+#define SecuredLinkedList_h
+
+
+template<class T>
+struct SecuredLinkedListNode {
+	T data;
+	SecuredLinkedListNode<T> *next;
+};
+
+template<class T>
+class SecuredLinkedList {
+	private:
+		SemaphoreHandle_t mtx;
+		unsigned int listSize;
+		SecuredLinkedListNode<T> *root;
+		SecuredLinkedListNode<T> *leaf;
+		virtual unsigned int sizeUnsecured();
+		virtual void pushUnsecured(T t);
+		virtual T popUnsecured();
+		virtual void addUnsecured(unsigned int index, T t);
+		virtual T getUnsecured(unsigned int index);
+		virtual void unshiftUnsecured(T t);
+		virtual T shiftUnsecured();
+		virtual void clearUnsecured();
+	public:
+		SecuredLinkedList(void);
+		~SecuredLinkedList(void);
+		virtual unsigned int size();
+		virtual void push(T t);
+		virtual T pop();
+		virtual void add(unsigned int index, T t);
+		virtual T get(unsigned int index);
+		virtual void unshift(T t);
+		virtual T shift();
+		virtual void clear();
+};
+
+template<typename T>
+SecuredLinkedList<T>::SecuredLinkedList()
+  : listSize(0), mtx(NULL), root(NULL), leaf(NULL)
+{
+	mtx = xSemaphoreCreateMutex();
+}
+
+template<typename T>
+SecuredLinkedList<T>::~SecuredLinkedList() {
+	vSemaphoreDelete(mtx);
+  clearUnsecured();
+}
+
+template<typename T>
+unsigned int SecuredLinkedList<T>::size() {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	unsigned int returnVal = sizeUnsecured();
+  xSemaphoreGive(mtx);
+  return returnVal;
+}
+template<typename T>
+unsigned int SecuredLinkedList<T>::sizeUnsecured() {
+	return listSize;
+}
+
+template<typename T>
+void SecuredLinkedList<T>::push(T t) {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	pushUnsecured(t);
+  xSemaphoreGive(mtx);
+}
+template<typename T>
+void SecuredLinkedList<T>::pushUnsecured(T t) {
+	SecuredLinkedListNode<T> *cache = new SecuredLinkedListNode<T>();
+	cache->data = t;
+	if(listSize <= 0) {
+		root = cache;
+		leaf = cache;
+		listSize += 1;
+	} else if(listSize == 1) {
+		root->next = cache;
+		leaf = cache;
+		listSize += 1;
+	} else {
+		leaf->next = cache;
+		leaf = cache;
+		listSize += 1;
+	}
+}
+
+template<typename T>
+T SecuredLinkedList<T>::pop() {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	T returnVal = popUnsecured();
+  xSemaphoreGive(mtx);
+  return returnVal;
+}
+template<typename T>
+T SecuredLinkedList<T>::popUnsecured() {
+	if(listSize <= 0) {
+		return T();
+	} else if(listSize > 1) {
+		T cache = leaf->data;
+		SecuredLinkedListNode<T> *previous = root;
+		while(previous->next->next != NULL) {
+			previous = previous->next;
+		}
+		leaf = previous;
+		leaf->next = NULL;
+		listSize -= 1;
+		return cache;
+	} else {
+		T cache = root->data;
+		root = NULL;
+		leaf = NULL;
+		listSize -= 1;
+		return cache;
+	}
+}
+
+template<typename T>
+void SecuredLinkedList<T>::add(unsigned int index, T t) {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	addUnsecured(index, t);
+  xSemaphoreGive(mtx);
+}
+template<typename T>
+void SecuredLinkedList<T>::addUnsecured(unsigned int index, T t) {
+	if(index <= 0) {
+		unshiftUnsecured(t);
+	} else if (index >= (listSize - 1)) {
+		pushUnsecured(t);
+	} else {
+		SecuredLinkedListNode<T> *previous = root;
+		for(unsigned int i = 1; i < index; i++) {
+			previous = previous->next;
+		}
+		SecuredLinkedListNode<T> *cache = new SecuredLinkedListNode<T>();
+		cache->data = t;
+		cache->next = previous->next;
+		previous->next = cache;
+		listSize += 1;
+	}
+}
+
+template<typename T>
+T SecuredLinkedList<T>::get(unsigned int index) {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	T returnVal = getUnsecured(index);
+  xSemaphoreGive(mtx);
+  return returnVal;
+}
+template<typename T>
+T SecuredLinkedList<T>::getUnsecured(unsigned int index) {
+	if(index <= 0) {
+		return root->data;
+	} else {
+		SecuredLinkedListNode<T> *previous = root;
+		for(unsigned int i = 0; i < index; i++) {
+			previous = previous->next;
+		}
+		return previous->data;
+	}
+}
+
+template<typename T>
+void SecuredLinkedList<T>::unshift(T t) {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	unshiftUnsecured(t);
+  xSemaphoreGive(mtx);
+}
+template<typename T>
+void SecuredLinkedList<T>::unshiftUnsecured(T t) {
+	if(listSize <= 0) {
+		pushUnsecured(t);
+	} else {
+		SecuredLinkedListNode<T> *cache = new SecuredLinkedListNode<T>();
+		cache->data = t;
+		cache->next = root;
+		root = cache;
+		listSize += 1;
+		if(listSize == 2) {
+			leaf = root->next;
+		}
+	}
+}
+
+template<typename T>
+T SecuredLinkedList<T>::shift() {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	T returnVal = shiftUnsecured();
+  xSemaphoreGive(mtx);
+  return returnVal;
+}
+template<typename T>
+T SecuredLinkedList<T>::shiftUnsecured() {
+	if(listSize <= 0) {
+		return T();
+	}
+	if(listSize > 1) {
+		T cache = root->data;
+		root = root->next;
+		listSize -= 1;
+		return cache;
+	} else {
+		return popUnsecured();
+	}
+}
+
+template<typename T>
+void SecuredLinkedList<T>::clear() {
+  xSemaphoreTake(mtx, portMAX_DELAY);
+	clearUnsecured();
+  xSemaphoreGive(mtx);
+}
+template<typename T>
+void SecuredLinkedList<T>::clearUnsecured() {
+	SecuredLinkedListNode<T> *tmp = root;
+  while(root!=NULL) {
+    tmp = root;
+    root = root->next;
+    delete tmp; // Delete item
+    listSize--; // Decrease counter
+  }
+  leaf = NULL;
+}
+
+#endif

--- a/test/UnitTests/TestVehicleController/SecuredLinkedListMap.h
+++ b/test/UnitTests/TestVehicleController/SecuredLinkedListMap.h
@@ -1,0 +1,214 @@
+// Created by Steven Cybinski
+// GitHub: https://github.com/StevenCyb/SecuredLinkedListMap
+// Features changed for this project:
+// - replaced std::mutex with FreeRTOS mutex
+// - added object initiliser list (important for functionality)
+// - added clear function to destructor to prevent heap issues
+// - delete all nodes in clear function to prevent heap issues
+// - when deleting nodes, delete the value too (specific to this project)
+
+#ifndef SecuredLinkedListMap_h
+#define SecuredLinkedListMap_h
+
+template<typename T1, typename T2> 
+struct SecuredLinkedListMapNode {
+	T1 key;
+	T2 value;
+	SecuredLinkedListMapNode<T1, T2> *next;
+};
+template<typename T1, typename T2> 
+struct SecuredLinkedListMapElement {
+	T1 key;
+	T2 value;
+};
+
+template<typename T1, typename T2> 
+class SecuredLinkedListMap {
+	private:
+		SemaphoreHandle_t mtx;
+		int bucketSize;
+		SecuredLinkedListMapNode<T1, T2> *bucketRoot;
+		virtual int sizeUnsecured();
+		virtual void putUnsecured(T1 key, T2 value);
+		virtual bool hasUnsecured(T1 key);
+		virtual void getAllUnsecured(SecuredLinkedListMapElement<T1, T2>* copies);
+		virtual T2 getUnsecured(T1 key);
+		virtual void removeUnsecured(T1 key);
+		virtual void clearUnsecured();
+	public:
+		SecuredLinkedListMap(void);
+		~SecuredLinkedListMap(void);
+		virtual int size();
+		virtual void put(T1 key, T2 value);
+		virtual bool has(T1 key);
+		virtual void getAll(SecuredLinkedListMapElement<T1, T2>* copies);
+		virtual T2 get(T1 key);
+		virtual void remove(T1 key);
+		virtual void clear();
+};
+
+template<typename T1, typename T2> 
+SecuredLinkedListMap<T1, T2>::SecuredLinkedListMap()
+  : mtx(NULL), bucketSize(0), bucketRoot(NULL)
+{
+	bucketSize = 0;
+	mtx = xSemaphoreCreateMutex();
+}
+
+template<typename T1, typename T2> 
+SecuredLinkedListMap<T1, T2>::~SecuredLinkedListMap() {
+	vSemaphoreDelete(mtx);
+	clearUnsecured();
+}
+
+template<typename T1, typename T2> 
+int SecuredLinkedListMap<T1, T2>::size() {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	int returnVal = sizeUnsecured();
+	xSemaphoreGive(mtx);
+	return returnVal;
+}
+template<typename T1, typename T2> 
+int SecuredLinkedListMap<T1, T2>::sizeUnsecured() {
+	return bucketSize;
+}
+
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::put(T1 key, T2 value) {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	putUnsecured(key, value);
+	xSemaphoreGive(mtx);
+}
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::putUnsecured(T1 key, T2 value) {
+	if(bucketSize <= 0) {
+		SecuredLinkedListMapNode<T1, T2> *cache = new SecuredLinkedListMapNode<T1, T2>();
+		cache->key = key;
+		cache->value = value;
+		bucketRoot = cache;
+		bucketSize += 1;
+	} else {
+		SecuredLinkedListMapNode<T1, T2> *current = bucketRoot;
+		if(current->key == key) {
+			current->value = value;
+			return;
+		}
+		while(current->next != NULL) {
+			current = current->next;
+			if(current->key == key) {
+				current->value = value;
+				return;
+			}
+		}
+		SecuredLinkedListMapNode<T1, T2> *cache = new SecuredLinkedListMapNode<T1, T2>();
+		cache->key = key;
+		cache->value = value;
+		current->next = cache;
+		bucketSize += 1;
+	}
+}
+
+template<typename T1, typename T2> 
+bool SecuredLinkedListMap<T1, T2>::has(T1 key) {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	bool returnVal = hasUnsecured(key);
+	xSemaphoreGive(mtx);
+	return returnVal;
+}
+template<typename T1, typename T2> 
+bool SecuredLinkedListMap<T1, T2>::hasUnsecured(T1 key) {
+	SecuredLinkedListMapNode<T1, T2> *current = bucketRoot;
+	while(current != NULL) {
+		if(current->key == key) {
+			return true;
+		}
+		current = current->next;
+	}
+	return false;
+}
+
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::getAll(SecuredLinkedListMapElement<T1, T2>* copies) {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	getAllUnsecured(copies);
+	xSemaphoreGive(mtx);
+}
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::getAllUnsecured(SecuredLinkedListMapElement<T1, T2>* copies) {
+	int counter = 0;
+	SecuredLinkedListMapNode<T1, T2> *current = bucketRoot;
+	while(current != NULL) {
+		SecuredLinkedListMapElement<T1, T2> copy = SecuredLinkedListMapElement<T1, T2>();
+		copy.key = current->key;
+		copy.value = current->value;
+		copies[counter] = copy;
+		current = current->next;
+		counter ++;
+	}
+}
+
+template<typename T1, typename T2> 
+T2 SecuredLinkedListMap<T1, T2>::get(T1 key) {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	T2 returnVal = getUnsecured(key);
+	xSemaphoreGive(mtx);
+	return returnVal;
+}
+template<typename T1, typename T2> 
+T2 SecuredLinkedListMap<T1, T2>::getUnsecured(T1 key) {
+	SecuredLinkedListMapNode<T1, T2> *current = bucketRoot;
+	if(current->key == key) {
+		return current->value;
+	}
+	while(current->next != NULL) {
+		current = current->next;
+		if(current->key == key) {
+			return current->value;
+		}
+	}
+	return T2();
+}
+
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::remove(T1 key) {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	removeUnsecured(key);
+	xSemaphoreGive(mtx);
+}
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::removeUnsecured(T1 key) {
+	SecuredLinkedListMapNode<T1, T2> *current = bucketRoot;
+	if(current->key == key) {
+		bucketRoot = current->next;
+		bucketSize -= 1;
+		return;
+	}
+	while(current->next != NULL) {
+		if(current->next->key == key) {
+			current->next = current->next->next;
+			bucketSize -= 1;
+			return;
+		}
+		current = current->next;
+	}
+}
+
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::clear() {
+	xSemaphoreTake(mtx, portMAX_DELAY);
+	clearUnsecured();
+	xSemaphoreGive(mtx);
+}
+template<typename T1, typename T2> 
+void SecuredLinkedListMap<T1, T2>::clearUnsecured() {
+  SecuredLinkedListMapNode<T1, T2> *tmp = bucketRoot;
+	while(bucketRoot != NULL) {
+    tmp = bucketRoot;
+		bucketRoot = bucketRoot->next;
+    delete tmp->value; // specific to this project: delete object on heap
+    delete tmp;
+    bucketSize--;
+	}
+}
+
+#endif

--- a/test/UnitTests/TestVehicleController/VehicleController.cpp
+++ b/test/UnitTests/TestVehicleController/VehicleController.cpp
@@ -1,0 +1,79 @@
+#include "VehicleController.h"
+
+
+bool VehicleController::registerParameter(Parameter* pParam)
+{
+  return m_map.addParameterToMap(pParam);
+}
+
+
+bool VehicleController::registerForValueChanged(Device* pCallingDevide, int id)
+{
+  return m_map.registerForValueChanged(pCallingDevide, id);
+}
+
+
+bool VehicleController::unregisterForValueChanged(Device* pCallingDevide, int id)
+{
+	return m_map.unregisterForValueChanged(pCallingDevide, id);
+}
+
+/*
+bool VehicleController::unregisterForAll(Device* pCallingDevide)
+{
+	return m_map.unregisterDevice(pCallingDevide);
+}
+*/
+
+bool VehicleController::setBooleanValue(Device* pCallingDevide, ParameterBool* pParam, bool val)
+{
+  // Check whether the value has changed
+  if (pParam->getVal() != val) {
+    pParam->setVal(val);
+    // Notify all Devices that have subscribed to this parameter
+    SecuredLinkedList<Device*>* devList = m_map.getRegisteredDevices(pParam->getId());
+    if (devList) {
+      for (int i=0; i<devList->size(); i++) {
+        devList->get(i)->notifyValueChanged(pParam);
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+
+bool VehicleController::setDoubleValue(Device* pCallingDevide, ParameterDouble* pParam, double val)
+{
+  // Check whether the value has changed
+  if (pParam->getVal() != val) {
+    pParam->setVal(val);
+    // Notify all Devices that have subscribed to this parameter
+    SecuredLinkedList<Device*>* devList = m_map.getRegisteredDevices(pParam->getId());
+    if (devList) {
+      for (int i=0; i<devList->size(); i++) {
+        devList->get(i)->notifyValueChanged(pParam);
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+
+bool VehicleController::setIntegerValue(Device* pCallingDevide, ParameterInt* pParam, int val)
+{
+  // Check whether the value has changed
+  if (pParam->getVal() != val) {
+    pParam->setVal(val);
+    // Notify all Devices that have subscribed to this parameter
+    SecuredLinkedList<Device*>* devList = m_map.getRegisteredDevices(pParam->getId());
+    if (devList) {
+      for (int i=0; i<devList->size(); i++) {
+        devList->get(i)->notifyValueChanged(pParam);
+      }
+      return true;
+    }
+  }
+  return false;
+}

--- a/test/UnitTests/TestVehicleController/VehicleController.h
+++ b/test/UnitTests/TestVehicleController/VehicleController.h
@@ -1,0 +1,33 @@
+/* ======================================================================
+ * The vehicle controller coordinates parameter changes and subscriptions.
+ * It starts devices (services) and shuts them down, but does not
+ * orchestrate anything.
+ */
+
+#ifndef VEHICLECONTROLLER_H
+#define VEHICLECONTROLLER_H
+
+#include <Arduino.h>
+#include "MapParameterToDevices.h"
+
+class Device;
+class Parameter;
+
+class VehicleController
+{
+public:
+	VehicleController() : m_map(MapParameterToDevices()) {};
+	~VehicleController() {};
+  bool registerParameter(Parameter* pParam);
+  bool registerForValueChanged(Device* pCallingDevide, int id);
+	bool unregisterForValueChanged(Device* pCallingDevide, int id);
+	//bool unregisterForAll(Device* pCallingDevide);
+	bool setBooleanValue(Device* pCallingDevide, ParameterBool* pParam, bool bValue);
+	bool setDoubleValue(Device* pCallingDevide, ParameterDouble* pParam, double dValue);
+	bool setIntegerValue(Device* pCallingDevide, ParameterInt* pParam, int nValue);
+
+private:
+	MapParameterToDevices m_map;
+};
+
+#endif


### PR DESCRIPTION
When running tests in TestMapParameterToDevices, everything works successfully. When taking that code into one logic level higher, the TestVehicleController tests, it fails with heap issues as soon as the object's destructor is called. Decoding the ESP32 backtrace shows that the code breaks down when the destructor of MapParameterToDevices (or its parent class) calls the destructor of the FreeRTOS mutex. I suspect a design flaw in SecuredLinkedList or SecuredLinkedListMap.